### PR TITLE
Update meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,10 +25,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.8
     - pip
   run:
-    - python >=3.6
+    - python >=3.8
     - setuptools
     - h5py >=2.10
     - numpy >=1.20
@@ -44,6 +44,7 @@ requirements:
     - requests >=2.20
     - toml >=0.10.2
     - pyproj >=1.9
+    - numba >=0.56
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - pandas.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - oq = openquake.commands.__main__:oq


### PR DESCRIPTION
We do not support  python 3.6 and python 3.7 and also numba is required for Openquake Engine